### PR TITLE
Fix hours_to_expiry for non-string date values

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ def hours_to_expiry(market: Dict[str, Any]) -> float:
         market.get("endsAt")
         or market.get("endDate")
         or market.get("expiry"))
-    if not date_str:
+    if not isinstance(date_str, str) or not date_str:
         return 0.0
     try:
         dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))


### PR DESCRIPTION
## Summary
- handle non-string dates in `hours_to_expiry`

## Testing
- `python -m py_compile app/main.py`