### PR TITLE
Add interactive filters and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ def hours_to_expiry(market: Dict[str, Any]) -> float:
         market.get("endsAt")
         or market.get("endDate")
         or market.get("expiry"))
-    if not date_str:
+    if not isinstance(date_str, str) or not date_str:
         return 0.0
     try:
         dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
@@ -58,8 +58,70 @@ def load_dataframe() -> pd.DataFrame:
     """Load markets into a DataFrame with computed columns."""
     markets = asyncio.run(fetch_markets())
     df = pd.DataFrame(markets)
-    if not df.empty:
-        df["hoursToExpiry"] = df.apply(hours_to_expiry, axis=1)
+    if df.empty:
+        return df
+
+    df["probability"] = df[["yesPrice", "noPrice"]].max(axis=1, skipna=True)
+    df["hoursLeft"] = df.apply(hours_to_expiry, axis=1)
+    return df
+
+
+def filter_dataframe(
+    df: pd.DataFrame,
+    search: str,
+    categories: list[str],
+    all_categories: list[str],
+    hide_sports: bool,
+    min_prob: float,
+    min_hours: float,
+    min_open_interest: float,
+) -> pd.DataFrame:
+    """Apply all filters to the markets DataFrame."""
+
+    result = df.copy()
+
+    if search:
+        search_lower = search.lower()
+        mask = False
+        if "question" in result.columns:
+            mask |= result["question"].astype(str).str.lower().str.contains(search_lower)
+        if "slug" in result.columns:
+            mask |= result["slug"].astype(str).str.lower().str.contains(search_lower)
+        result = result[mask]
+
+    if categories and len(categories) != len(all_categories) and "category" in result.columns:
+        result = result[result["category"].isin(categories)]
+
+    if hide_sports and "category" in result.columns:
+        result = result[result["category"].str.lower() != "sports"]
+
+    if "probability" in result.columns:
+        result = result[result["probability"] >= min_prob]
+
+    if "hoursLeft" in result.columns:
+        result = result[result["hoursLeft"] >= min_hours]
+
+    if "openInterest" in result.columns:
+        result = result[result["openInterest"] >= min_open_interest]
+
+    return result
+
+
+SORT_OPTIONS = {
+    "24h volume": ("volume24hr", False),
+    "openInterest": ("openInterest", False),
+    "endDate asc": ("hoursLeft", True),
+    "endDate desc": ("hoursLeft", False),
+    "probability asc": ("probability", True),
+    "probability desc": ("probability", False),
+}
+
+
+def sort_dataframe(df: pd.DataFrame, option: str) -> pd.DataFrame:
+    """Sort the DataFrame according to the selected option."""
+    col, ascending = SORT_OPTIONS.get(option, ("volume24hr", False))
+    if col in df.columns:
+        return df.sort_values(col, ascending=ascending)
     return df
 
 
@@ -68,31 +130,40 @@ def main() -> None:
     st.title("Polymarket Markets (Read-Only)")
 
     st.sidebar.header("Filters")
-    min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
-    min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
-    min_open_interest = st.sidebar.number_input(
-        "Min openInterest USDC", value=1000, step=100
-    )
+    search = st.sidebar.text_input("Search")
 
     df = load_dataframe()
+    total_markets = len(df)
+    st.markdown(f"**Total markets loaded:** {total_markets}")
+
     if df.empty:
         st.info("No market data available.")
         return
 
-    df_filtered = df.copy()
-    if "yesPrice" in df_filtered.columns and "noPrice" in df_filtered.columns:
-        prob_col = df_filtered[["yesPrice", "noPrice"]].max(axis=1)
-        df_filtered = df_filtered[prob_col >= min_prob]
+    categories_all = sorted(df["category"].dropna().unique().tolist()) if "category" in df.columns else []
+    selected_categories = st.sidebar.multiselect("Categories", categories_all, default=categories_all)
+    hide_sports = st.sidebar.checkbox("Hide sports markets")
+    min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
+    min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
+    min_open_interest = st.sidebar.number_input("Min openInterest", value=1000, step=100)
+    sort_option = st.sidebar.selectbox("Sort by", list(SORT_OPTIONS.keys()))
 
-    if "hoursToExpiry" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["hoursToExpiry"] >= min_hours]
+    df_filtered = filter_dataframe(
+        df,
+        search,
+        selected_categories,
+        categories_all,
+        hide_sports,
+        min_prob,
+        min_hours,
+        min_open_interest,
+    )
 
-    if "openInterest" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
+    df_filtered = sort_dataframe(df_filtered, sort_option)
 
     columns = [
         col
-        for col in ["question", "yesPrice", "noPrice", "openInterest", "hoursToExpiry"]
+        for col in ["question", "yesPrice", "noPrice", "probability", "hoursLeft", "openInterest", "volume24hr", "category"]
         if col in df_filtered.columns
     ]
     st.dataframe(df_filtered[columns])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,55 @@
+import pandas as pd
+from app.main import filter_dataframe, sort_dataframe
+
+
+def sample_df():
+    return pd.DataFrame([
+        {
+            "question": "Foo?",
+            "slug": "foo",
+            "category": "Politics",
+            "probability": 0.9,
+            "hoursLeft": 10,
+            "openInterest": 2000,
+            "volume24hr": 500,
+        },
+        {
+            "question": "Bar?",
+            "slug": "bar",
+            "category": "Sports",
+            "probability": 0.6,
+            "hoursLeft": 2,
+            "openInterest": 800,
+            "volume24hr": 100,
+        },
+    ])
+
+
+def test_probability_filter():
+    df = sample_df()
+    out = filter_dataframe(df, "", [], [], False, 0.7, 0, 0)
+    assert len(out) == 1
+
+
+def test_hide_sports():
+    df = sample_df()
+    out = filter_dataframe(df, "", [], ["Politics", "Sports"], True, 0, 0, 0)
+    assert "Sports" not in out["category"].values
+
+
+def test_search():
+    df = sample_df()
+    out = filter_dataframe(df, "foo", [], ["Politics", "Sports"], False, 0, 0, 0)
+    assert len(out) == 1 and out.iloc[0]["slug"] == "foo"
+
+
+def test_category_filter():
+    df = sample_df()
+    out = filter_dataframe(df, "", ["Politics"], ["Politics", "Sports"], False, 0, 0, 0)
+    assert out["category"].unique().tolist() == ["Politics"]
+
+
+def test_sorting():
+    df = sample_df()
+    out = sort_dataframe(df, "probability desc")
+    assert out.iloc[0]["probability"] >= out.iloc[1]["probability"]


### PR DESCRIPTION
## Summary
- compute `probability` and `hoursLeft`
- add sidebar search, category, sports toggle, sliders, and sort box
- filter and sort markets in a new helper
- show total markets loaded
- add tests for filtering logic

## Testing
- `python -m py_compile app/main.py tests/test_filters.py`
- `python -m pytest -q` *(fails: No module named pytest)*