### PR TITLE
Enhance UI filtering and add tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Iterable
 
 import httpx
 import pandas as pd
@@ -44,7 +44,7 @@ def hours_to_expiry(market: Dict[str, Any]) -> float:
         market.get("endsAt")
         or market.get("endDate")
         or market.get("expiry"))
-    if not date_str:
+    if not isinstance(date_str, str) or not date_str:
         return 0.0
     try:
         dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
@@ -54,12 +54,90 @@ def hours_to_expiry(market: Dict[str, Any]) -> float:
     return round(delta.total_seconds() / 3600, 2)
 
 
+def add_computed_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of ``df`` with ``probability`` and ``hoursLeft`` columns."""
+    result = df.copy()
+    if {"yesPrice", "noPrice"}.issubset(result.columns):
+        result["probability"] = result[["yesPrice", "noPrice"]].max(axis=1, skipna=True)
+    else:
+        result["probability"] = pd.NA
+    result["hoursLeft"] = result.apply(hours_to_expiry, axis=1)
+    return result
+
+
+def filter_dataframe(
+    df: pd.DataFrame,
+    search: str,
+    categories: Iterable[str] | None,
+    hide_sports: bool,
+    min_prob: float,
+    min_hours: int,
+    min_open: int,
+) -> pd.DataFrame:
+    """Filter ``df`` according to sidebar controls."""
+    result = df.copy()
+
+    if search:
+        text = search.lower()
+        q_match = result["question"].str.contains(text, case=False, na=False) if "question" in result.columns else False
+        slug_match = result.get("slug", pd.Series(""))
+        if isinstance(slug_match, pd.Series):
+            slug_match = slug_match.str.contains(text, case=False, na=False)
+        else:
+            slug_match = False
+        result = result[q_match | slug_match]
+
+    if hide_sports and "category" in result.columns:
+        result = result[~result["category"].str.contains("sports", case=False, na=False)]
+
+    if categories and "category" in result.columns and "All" not in categories:
+        result = result[result["category"].isin(categories)]
+
+    if "probability" in result.columns:
+        result = result[result["probability"] >= min_prob]
+
+    if "hoursLeft" in result.columns:
+        result = result[result["hoursLeft"] >= min_hours]
+
+    if "openInterest" in result.columns:
+        result = result[result["openInterest"] >= min_open]
+
+    return result
+
+
+def sort_dataframe(df: pd.DataFrame, option: str) -> pd.DataFrame:
+    """Sort ``df`` according to the selected option."""
+    if option == "24h volume" and "volume24hr" in df.columns:
+        return df.sort_values("volume24hr", ascending=False)
+    if option == "openInterest" and "openInterest" in df.columns:
+        return df.sort_values("openInterest", ascending=False)
+
+    date_col = None
+    for col in ("endDate", "endsAt", "expiry"):
+        if col in df.columns:
+            date_col = col
+            break
+
+    if option == "endDate asc" and date_col:
+        return df.sort_values(date_col, ascending=True)
+    if option == "endDate desc" and date_col:
+        return df.sort_values(date_col, ascending=False)
+
+    if option == "probability asc" and "probability" in df.columns:
+        return df.sort_values("probability", ascending=True)
+    if option == "probability desc" and "probability" in df.columns:
+        return df.sort_values("probability", ascending=False)
+
+    return df
+
+
 def load_dataframe() -> pd.DataFrame:
     """Load markets into a DataFrame with computed columns."""
     markets = asyncio.run(fetch_markets())
     df = pd.DataFrame(markets)
-    if not df.empty:
-        df["hoursToExpiry"] = df.apply(hours_to_expiry, axis=1)
+    if df.empty:
+        return df
+    df = add_computed_columns(df)
     return df
 
 
@@ -67,33 +145,60 @@ def main() -> None:
     st.set_page_config(page_title="Polymarket Browser", layout="wide")
     st.title("Polymarket Markets (Read-Only)")
 
+    df = load_dataframe()
+    st.write(f"Total markets loaded: {len(df)}")
+
     st.sidebar.header("Filters")
+    search_text = st.sidebar.text_input("Search question or slug")
+    categories = ["All"]
+    if "category" in df.columns:
+        categories += sorted(c for c in df["category"].dropna().unique())
+    selected_categories = st.sidebar.multiselect("Category", categories, default=["All"])
+    hide_sports = st.sidebar.checkbox("Hide sports markets")
     min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
     min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
     min_open_interest = st.sidebar.number_input(
         "Min openInterest USDC", value=1000, step=100
     )
-
-    df = load_dataframe()
+    sort_option = st.sidebar.selectbox(
+        "Sort by",
+        [
+            "24h volume",
+            "openInterest",
+            "endDate asc",
+            "endDate desc",
+            "probability asc",
+            "probability desc",
+        ],
+    )
     if df.empty:
         st.info("No market data available.")
         return
 
-    df_filtered = df.copy()
-    if "yesPrice" in df_filtered.columns and "noPrice" in df_filtered.columns:
-        prob_col = df_filtered[["yesPrice", "noPrice"]].max(axis=1)
-        df_filtered = df_filtered[prob_col >= min_prob]
-
-    if "hoursToExpiry" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["hoursToExpiry"] >= min_hours]
-
-    if "openInterest" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
+    df_filtered = filter_dataframe(
+        df,
+        search_text,
+        selected_categories,
+        hide_sports,
+        min_prob,
+        min_hours,
+        int(min_open_interest),
+    )
+    df_filtered = sort_dataframe(df_filtered, sort_option)
 
     columns = [
-        col
-        for col in ["question", "yesPrice", "noPrice", "openInterest", "hoursToExpiry"]
-        if col in df_filtered.columns
+        c
+        for c in [
+            "question",
+            "yesPrice",
+            "noPrice",
+            "probability",
+            "hoursLeft",
+            "openInterest",
+            "volume24hr",
+            "category",
+        ]
+        if c in df_filtered.columns
     ]
     st.dataframe(df_filtered[columns])
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,56 @@
+import pandas as pd
+from app.main import add_computed_columns, filter_dataframe, sort_dataframe
+
+
+def example_df():
+    data = [
+        {
+            "question": "Will team A win?",
+            "slug": "team-a-win",
+            "category": "Sports",
+            "yesPrice": 0.9,
+            "noPrice": 0.1,
+            "openInterest": 2000,
+            "volume24hr": 50,
+            "endDate": "2030-01-01T00:00:00Z",
+        },
+        {
+            "question": "Will candidate X be elected?",
+            "slug": "candidate-x-election",
+            "category": "Politics",
+            "yesPrice": 0.6,
+            "noPrice": 0.4,
+            "openInterest": 500,
+            "volume24hr": 100,
+            "endDate": "2030-01-02T00:00:00Z",
+        },
+    ]
+    df = pd.DataFrame(data)
+    return add_computed_columns(df)
+
+
+def test_search_filter():
+    df = example_df()
+    result = filter_dataframe(df, "candidate", None, False, 0.0, 0, 0)
+    assert len(result) == 1
+    assert result.iloc[0]["slug"] == "candidate-x-election"
+
+
+def test_hide_sports():
+    df = example_df()
+    result = filter_dataframe(df, "", None, True, 0.0, 0, 0)
+    assert all(result["category"] != "Sports")
+
+
+def test_probability_filter():
+    df = example_df()
+    result = filter_dataframe(df, "", None, False, 0.8, 0, 0)
+    assert len(result) == 1
+    assert result.iloc[0]["slug"] == "team-a-win"
+
+
+def test_sort_open_interest():
+    df = example_df()
+    sorted_df = sort_dataframe(df, "openInterest")
+    assert sorted_df.iloc[0]["openInterest"] >= sorted_df.iloc[1]["openInterest"]
+


### PR DESCRIPTION
## Summary
- compute `probability` and `hoursLeft` once for all markets
- add functions to filter and sort a DataFrame
- extend Streamlit UI with search, categories, hide sports, and sort options
- show total markets loaded at runtime
- create unit tests covering filters and sorting

## Testing
- `python -m py_compile app/main.py tests/test_filters.py`
- `python -m pytest -q` *(fails: No module named pytest)*