### PR TITLE
Normalize data before filtering

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Sequence
 
 import httpx
 import pandas as pd
@@ -38,18 +38,27 @@ async def fetch_markets() -> List[Dict[str, Any]]:
     return markets
 
 
-def hours_to_expiry(market: Dict[str, Any]) -> float:
-    """Return the remaining hours until market resolution."""
+def hours_left(row: Dict[str, Any]) -> float:
+    """Return the remaining hours until market resolution.
+
+    Accepts ISO strings with or without ``Z``. If parsing fails, returns ``-1``.
+    """
     date_str = (
-        market.get("endsAt")
-        or market.get("endDate")
-        or market.get("expiry"))
-    if not date_str:
-        return 0.0
+        row.get("endsAt")
+        or row.get("endDate")
+        or row.get("expiry"))
+    if not isinstance(date_str, str) or not date_str:
+        return -1.0
     try:
-        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        if date_str.endswith("Z"):
+            dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        else:
+            dt = datetime.fromisoformat(date_str)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
     except ValueError:
-        return 0.0
+        return -1.0
+
     delta = dt - datetime.now(timezone.utc)
     return round(delta.total_seconds() / 3600, 2)
 
@@ -59,40 +68,133 @@ def load_dataframe() -> pd.DataFrame:
     markets = asyncio.run(fetch_markets())
     df = pd.DataFrame(markets)
     if not df.empty:
-        df["hoursToExpiry"] = df.apply(hours_to_expiry, axis=1)
+        add_computed_columns(df)
     return df
+
+
+def apply_filters(
+    df: pd.DataFrame,
+    *,
+    search: str = "",
+    categories: Sequence[str] | None = None,
+    hide_sports: bool = False,
+    min_prob: float = 0.85,
+    min_hours: float = 6.0,
+    min_open_interest: float = 1000.0,
+) -> pd.DataFrame:
+    """Return ``df`` filtered according to the provided values."""
+
+    out = df.copy()
+
+    if hide_sports and "category" in out.columns:
+        out = out[out["category"] != "Sports"]
+
+    if categories and "category" in out.columns:
+        out = out[out["category"].isin(categories)]
+
+    if search:
+        mask_q = (
+            out["question"].astype(str).str.contains(search, case=False, na=False)
+            if "question" in out.columns
+            else pd.Series(False, index=out.index)
+        )
+        mask_s = (
+            out["slug"].astype(str).str.contains(search, case=False, na=False)
+            if "slug" in out.columns
+            else pd.Series(False, index=out.index)
+        )
+        out = out[mask_q | mask_s]
+
+    if "probability" in out.columns:
+        out = out[out["probability"] >= min_prob]
+
+    if "hoursLeft" in out.columns:
+        out = out[out["hoursLeft"] >= min_hours]
+
+    if "openInterest" in out.columns:
+        out = out[out["openInterest"] >= min_open_interest]
+
+    return out
+
+
+def sort_df(df: pd.DataFrame, key: str, ascending: bool) -> pd.DataFrame:
+    """Return ``df`` sorted by the given column if present."""
+    if key in df.columns:
+        return df.sort_values(key, ascending=ascending)
+    return df
+
+
+def add_computed_columns(df: pd.DataFrame) -> None:
+    """Add ``probability`` and ``hoursLeft`` columns to ``df`` in-place."""
+    if {"yesPrice", "noPrice"}.issubset(df.columns):
+        df["probability"] = df[["yesPrice", "noPrice"]].max(axis=1, skipna=True)
+    else:
+        df["probability"] = pd.NA
+
+    df["hoursLeft"] = df.apply(hours_left, axis=1)
 
 
 def main() -> None:
     st.set_page_config(page_title="Polymarket Browser", layout="wide")
     st.title("Polymarket Markets (Read-Only)")
 
+    df = load_dataframe()
+    st.write(f"Total current available markets: {len(df)}")
+    if df.empty:
+        st.info("No market data available.")
+        return
+
+    categories = []
+    if "category" in df.columns:
+        categories = sorted([c for c in df["category"].dropna().unique()])
+
     st.sidebar.header("Filters")
+    search = st.sidebar.text_input("Search")
+    selected_categories = st.sidebar.multiselect(
+        "Category", categories, default=categories
+    )
+    hide_sports = st.sidebar.checkbox("Hide sports markets")
     min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
     min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
     min_open_interest = st.sidebar.number_input(
         "Min openInterest USDC", value=1000, step=100
     )
 
-    df = load_dataframe()
-    if df.empty:
-        st.info("No market data available.")
-        return
+    sort_map = {
+        "24h volume": ("volume24hr", False),
+        "openInterest": ("openInterest", False),
+        "endDate asc": ("endDate", True),
+        "endDate desc": ("endDate", False),
+        "probability asc": ("probability", True),
+        "probability desc": ("probability", False),
+    }
+    sort_choice = st.sidebar.selectbox("Sort by", list(sort_map.keys()))
 
-    df_filtered = df.copy()
-    if "yesPrice" in df_filtered.columns and "noPrice" in df_filtered.columns:
-        prob_col = df_filtered[["yesPrice", "noPrice"]].max(axis=1)
-        df_filtered = df_filtered[prob_col >= min_prob]
+    df_filtered = apply_filters(
+        df,
+        search=search,
+        categories=selected_categories,
+        hide_sports=hide_sports,
+        min_prob=min_prob,
+        min_hours=min_hours,
+        min_open_interest=min_open_interest,
+    )
 
-    if "hoursToExpiry" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["hoursToExpiry"] >= min_hours]
-
-    if "openInterest" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
+    sort_col, ascending = sort_map[sort_choice]
+    df_filtered = sort_df(df_filtered, sort_col, ascending)
 
     columns = [
         col
-        for col in ["question", "yesPrice", "noPrice", "openInterest", "hoursToExpiry"]
+        for col in [
+            "question",
+            "yesPrice",
+            "noPrice",
+            "probability",
+            "hoursLeft",
+            "openInterest",
+            "volume24hr",
+            "category",
+        ]
         if col in df_filtered.columns
     ]
     st.dataframe(df_filtered[columns])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from app.main import add_computed_columns, apply_filters
+
+def test_missing_end_date_filter():
+    df = pd.DataFrame([
+        {
+            "question": "Q1",
+            "yesPrice": 0.6,
+            "noPrice": 0.4,
+            "openInterest": 2000,
+            "endDate": "2030-01-01T00:00:00Z",
+            "category": "Politics",
+            "volume24hr": 10,
+        },
+        {
+            "question": "Q2",
+            "yesPrice": 0.7,
+            "noPrice": 0.3,
+            "openInterest": 2000,
+            "category": "Sports",
+            "volume24hr": 5,
+        },
+    ])
+    add_computed_columns(df)
+    assert df.loc[1, "hoursLeft"] == -1
+
+    out = apply_filters(
+        df,
+        min_hours=1,
+        categories=["Politics", "Sports"],
+        hide_sports=False,
+        min_prob=0.5,
+        min_open_interest=0,
+    )
+    assert len(out) == 1
+    assert out.iloc[0]["question"] == "Q1"
+


### PR DESCRIPTION
## Summary
- compute `probability` and `hoursLeft` once on load
- apply filters in correct order and add sorting helper
- show total markets loaded and new sidebar controls
- add a unit test for missing `endDate`

## Testing
- `python -m py_compile app/main.py tests/test_filters.py`
- `python -m pytest -q` *(fails: No module named pytest)*