### PR TITLE
Add filtering widgets and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -43,13 +43,14 @@ def hours_to_expiry(market: Dict[str, Any]) -> float:
     date_str = (
         market.get("endsAt")
         or market.get("endDate")
-        or market.get("expiry"))
-    if not date_str:
-        return 0.0
+        or market.get("expiry")
+    )
+    if not isinstance(date_str, str) or not date_str:
+        return -1.0
     try:
         dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
     except ValueError:
-        return 0.0
+        return -1.0
     delta = dt - datetime.now(timezone.utc)
     return round(delta.total_seconds() / 3600, 2)
 
@@ -59,7 +60,61 @@ def load_dataframe() -> pd.DataFrame:
     markets = asyncio.run(fetch_markets())
     df = pd.DataFrame(markets)
     if not df.empty:
-        df["hoursToExpiry"] = df.apply(hours_to_expiry, axis=1)
+        if {"yesPrice", "noPrice"}.issubset(df.columns):
+            df["probability"] = df[["yesPrice", "noPrice"]].max(axis=1, skipna=True)
+        df["hoursLeft"] = df.apply(hours_to_expiry, axis=1)
+    return df
+
+
+def filter_dataframe(
+    df: pd.DataFrame,
+    hide_sports: bool,
+    categories: List[str],
+    search: str,
+    min_prob: float,
+    min_hours: int,
+    min_open_interest: int,
+) -> pd.DataFrame:
+    """Apply sidebar filters to the markets DataFrame."""
+    df_filtered = df.copy()
+
+    if hide_sports and "category" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["category"].str.lower() != "sports"]
+
+    if categories and "category" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["category"].isin(categories)]
+
+    if search:
+        pattern = search.lower()
+        question_match = df_filtered.get("question", "").str.contains(pattern, case=False, na=False)
+        slug_match = df_filtered.get("slug", "").str.contains(pattern, case=False, na=False)
+        df_filtered = df_filtered[question_match | slug_match]
+
+    if "probability" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["probability"] >= min_prob]
+
+    if "hoursLeft" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["hoursLeft"] >= min_hours]
+
+    if "openInterest" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
+
+    return df_filtered
+
+
+def sort_dataframe(df: pd.DataFrame, option: str) -> pd.DataFrame:
+    """Sort markets according to the selected option."""
+    mapping = {
+        "24h volume": ("volume24hr", False),
+        "openInterest": ("openInterest", False),
+        "endDate asc": ("hoursLeft", True),
+        "endDate desc": ("hoursLeft", False),
+        "probability asc": ("probability", True),
+        "probability desc": ("probability", False),
+    }
+    col, ascending = mapping.get(option, (None, False))
+    if col and col in df.columns:
+        return df.sort_values(col, ascending=ascending, ignore_index=True)
     return df
 
 
@@ -67,32 +122,56 @@ def main() -> None:
     st.set_page_config(page_title="Polymarket Browser", layout="wide")
     st.title("Polymarket Markets (Read-Only)")
 
+    df = load_dataframe()
+    st.write(f"Total current available markets: {len(df)}")
+
     st.sidebar.header("Filters")
+    search_text = st.sidebar.text_input("Search")
+    categories = sorted(df.get("category", pd.Series(dtype=str)).dropna().unique().tolist())
+    selected_categories = st.sidebar.multiselect("Categories", categories, default=categories)
+    hide_sports = st.sidebar.checkbox("Hide sports markets")
     min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
     min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
     min_open_interest = st.sidebar.number_input(
         "Min openInterest USDC", value=1000, step=100
     )
+    sort_options = [
+        "24h volume",
+        "openInterest",
+        "endDate asc",
+        "endDate desc",
+        "probability asc",
+        "probability desc",
+    ]
+    sort_by = st.sidebar.selectbox("Sort by", sort_options)
 
-    df = load_dataframe()
     if df.empty:
         st.info("No market data available.")
         return
 
-    df_filtered = df.copy()
-    if "yesPrice" in df_filtered.columns and "noPrice" in df_filtered.columns:
-        prob_col = df_filtered[["yesPrice", "noPrice"]].max(axis=1)
-        df_filtered = df_filtered[prob_col >= min_prob]
-
-    if "hoursToExpiry" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["hoursToExpiry"] >= min_hours]
-
-    if "openInterest" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
+    df_filtered = filter_dataframe(
+        df,
+        hide_sports,
+        selected_categories,
+        search_text,
+        min_prob,
+        min_hours,
+        min_open_interest,
+    )
+    df_filtered = sort_dataframe(df_filtered, sort_by)
 
     columns = [
         col
-        for col in ["question", "yesPrice", "noPrice", "openInterest", "hoursToExpiry"]
+        for col in [
+            "question",
+            "yesPrice",
+            "noPrice",
+            "probability",
+            "hoursLeft",
+            "openInterest",
+            "volume24hr",
+            "category",
+        ]
         if col in df_filtered.columns
     ]
     st.dataframe(df_filtered[columns])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,65 @@
+import unittest
+from datetime import datetime, timezone, timedelta
+
+import pandas as pd
+
+from app.main import hours_to_expiry, filter_dataframe
+
+
+class FilterTests(unittest.TestCase):
+    def test_hours_to_expiry_missing(self) -> None:
+        market = {"endDate": None}
+        self.assertEqual(hours_to_expiry(market), -1.0)
+
+    def test_filter_sequence(self) -> None:
+        now = datetime.now(timezone.utc)
+        df = pd.DataFrame([
+            {
+                "question": "Will X happen?",
+                "slug": "x-happen",
+                "category": "Politics",
+                "yesPrice": 0.9,
+                "noPrice": 0.1,
+                "openInterest": 2000,
+                "volume24hr": 100,
+                "endDate": (now + timedelta(hours=10)).isoformat(),
+            },
+            {
+                "question": "Will Y happen?",
+                "slug": "y-happen",
+                "category": "Sports",
+                "yesPrice": 0.6,
+                "noPrice": 0.4,
+                "openInterest": 500,
+                "volume24hr": 50,
+                "endDate": (now + timedelta(hours=2)).isoformat(),
+            },
+            {
+                "question": "Will Z happen?",
+                "slug": "z-happen",
+                "category": "Politics",
+                "yesPrice": 0.7,
+                "noPrice": 0.3,
+                "openInterest": 1500,
+                "volume24hr": 10,
+                "endDate": None,
+            },
+        ])
+        df["probability"] = df[["yesPrice", "noPrice"]].max(axis=1)
+        df["hoursLeft"] = df.apply(hours_to_expiry, axis=1)
+
+        result = filter_dataframe(
+            df,
+            hide_sports=True,
+            categories=["Politics"],
+            search="will x",
+            min_prob=0.8,
+            min_hours=3,
+            min_open_interest=1000,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result.iloc[0]["slug"], "x-happen")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute `probability` and `hoursLeft` when loading markets
- filter by search, category, hours, probability and open interest
- sort results according to dropdown
- show total markets loaded
- add unit tests for hours_to_expiry and filter behavior

## Testing
- `python -m py_compile app/main.py tests/test_filters.py`
- `python -m unittest tests.test_filters -v`