### PR TITLE
Add filtering and sorting controls

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import httpx
 import pandas as pd
@@ -38,64 +38,138 @@ async def fetch_markets() -> List[Dict[str, Any]]:
     return markets
 
 
-def hours_to_expiry(market: Dict[str, Any]) -> float:
-    """Return the remaining hours until market resolution."""
-    date_str = (
-        market.get("endsAt")
-        or market.get("endDate")
-        or market.get("expiry"))
-    if not date_str:
-        return 0.0
+def hours_left(row: Dict[str, Any]) -> float:
+    """Return remaining hours until market resolution or -1 if unknown."""
+    date_str = row.get("endDate") or row.get("endsAt") or row.get("expiry")
+    if not isinstance(date_str, str) or not date_str:
+        return -1.0
     try:
         dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
     except ValueError:
-        return 0.0
+        return -1.0
     delta = dt - datetime.now(timezone.utc)
     return round(delta.total_seconds() / 3600, 2)
 
 
+def normalize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Add probability and hoursLeft columns."""
+    if df.empty:
+        return df
+    df = df.copy()
+    if {"yesPrice", "noPrice"}.issubset(df.columns):
+        df["probability"] = df[["yesPrice", "noPrice"]].max(axis=1, skipna=True)
+    else:
+        df["probability"] = 0.0
+    df["hoursLeft"] = df.apply(hours_left, axis=1)
+    return df
+
+
+def filter_dataframe(
+    df: pd.DataFrame,
+    search_text: str,
+    categories: List[str],
+    hide_sports: bool,
+    min_prob: float,
+    min_hours: int,
+    min_open: int,
+) -> pd.DataFrame:
+    """Apply sidebar filters in order."""
+    result = df.copy()
+
+    if hide_sports and "category" in result.columns:
+        result = result[result["category"].str.lower() != "sports"]
+
+    if categories and "category" in result.columns:
+        result = result[result["category"].isin(categories)]
+
+    if search_text:
+        mask_q = result["question"].str.contains(search_text, case=False, na=False)
+        mask_s = result["slug"].str.contains(search_text, case=False, na=False)
+        result = result[mask_q | mask_s]
+
+    if "probability" in result.columns:
+        result = result[result["probability"] >= min_prob]
+
+    if "hoursLeft" in result.columns:
+        result = result[result["hoursLeft"] >= min_hours]
+
+    if "openInterest" in result.columns:
+        result = result[result["openInterest"] >= min_open]
+
+    return result
+
+
+SORT_OPTIONS: Dict[str, Tuple[str, bool]] = {
+    "24h volume": ("volume24hr", False),
+    "openInterest": ("openInterest", False),
+    "endDate asc": ("endDate", True),
+    "endDate desc": ("endDate", False),
+    "probability asc": ("probability", True),
+    "probability desc": ("probability", False),
+}
+
+
+def sort_dataframe(df: pd.DataFrame, option: str) -> pd.DataFrame:
+    column, asc = SORT_OPTIONS.get(option, ("openInterest", False))
+    if column not in df.columns:
+        return df
+    return df.sort_values(column, ascending=asc)
+
+
 def load_dataframe() -> pd.DataFrame:
-    """Load markets into a DataFrame with computed columns."""
+    """Load and normalize markets into a DataFrame."""
     markets = asyncio.run(fetch_markets())
     df = pd.DataFrame(markets)
-    if not df.empty:
-        df["hoursToExpiry"] = df.apply(hours_to_expiry, axis=1)
-    return df
+    return normalize_dataframe(df)
 
 
 def main() -> None:
     st.set_page_config(page_title="Polymarket Browser", layout="wide")
     st.title("Polymarket Markets (Read-Only)")
 
-    st.sidebar.header("Filters")
-    min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
-    min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
-    min_open_interest = st.sidebar.number_input(
-        "Min openInterest USDC", value=1000, step=100
-    )
-
     df = load_dataframe()
+    st.write(f"Total current available markets: {len(df)}")
     if df.empty:
         st.info("No market data available.")
         return
 
-    df_filtered = df.copy()
-    if "yesPrice" in df_filtered.columns and "noPrice" in df_filtered.columns:
-        prob_col = df_filtered[["yesPrice", "noPrice"]].max(axis=1)
-        df_filtered = df_filtered[prob_col >= min_prob]
+    categories = sorted(df["category"].dropna().unique().tolist()) if "category" in df.columns else []
 
-    if "hoursToExpiry" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["hoursToExpiry"] >= min_hours]
+    st.sidebar.header("Filters")
+    search_text = st.sidebar.text_input("Search question or slug")
+    selected_categories = st.sidebar.multiselect("Categories", categories, default=categories)
+    hide_sports = st.sidebar.checkbox("Hide sports markets")
+    min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
+    min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
+    min_open = st.sidebar.number_input("Min openInterest USDC", value=1000, step=100)
+    sort_option = st.sidebar.selectbox("Sort by", list(SORT_OPTIONS.keys()))
 
-    if "openInterest" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
+    filtered = filter_dataframe(
+        df,
+        search_text,
+        selected_categories,
+        hide_sports,
+        min_prob,
+        min_hours,
+        min_open,
+    )
+    filtered = sort_dataframe(filtered, sort_option)
 
+    st.write(f"Showing {len(filtered)} markets after filters.")
     columns = [
-        col
-        for col in ["question", "yesPrice", "noPrice", "openInterest", "hoursToExpiry"]
-        if col in df_filtered.columns
+        "question",
+        "yesPrice",
+        "noPrice",
+        "probability",
+        "hoursLeft",
+        "openInterest",
+        "volume24hr",
+        "category",
     ]
-    st.dataframe(df_filtered[columns])
+    cols = [c for c in columns if c in filtered.columns]
+    st.dataframe(filtered[cols])
 
 
 if __name__ == "__main__":

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,61 @@
+import unittest
+import pandas as pd
+
+from app.main import normalize_dataframe, filter_dataframe
+
+
+class FilterTests(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame([
+            {
+                "question": "Will A happen",
+                "slug": "a-happen",
+                "yesPrice": 0.9,
+                "noPrice": 0.1,
+                "openInterest": 2000,
+                "category": "Politics",
+                "volume24hr": 100,
+                "endDate": "2030-01-01T00:00:00Z",
+            },
+            {
+                "question": "Will B happen",
+                "slug": "b-happen",
+                "yesPrice": 0.6,
+                "noPrice": 0.4,
+                "openInterest": 500,
+                "category": "Sports",
+                "volume24hr": 50,
+                "endDate": "2030-01-01T00:00:00Z",
+            },
+            {
+                "question": "Will C happen",
+                "slug": "c-happen",
+                "yesPrice": 0.4,
+                "noPrice": 0.6,
+                "openInterest": 1500,
+                "category": "Politics",
+                "volume24hr": 20,
+                "endDate": None,
+            },
+        ])
+        self.df = normalize_dataframe(self.df)
+
+    def test_min_prob(self):
+        filtered = filter_dataframe(self.df, "", ["Politics", "Sports"], False, 0.7, 0, 0)
+        self.assertEqual(len(filtered), 1)
+
+    def test_hide_sports(self):
+        filtered = filter_dataframe(self.df, "", ["Politics", "Sports"], True, 0.0, 0, 0)
+        self.assertNotIn("Sports", filtered["category"].tolist())
+
+    def test_min_hours(self):
+        filtered = filter_dataframe(self.df, "", ["Politics", "Sports"], False, 0.0, 1, 0)
+        self.assertTrue(filtered["hoursLeft"].min() >= 1)
+
+    def test_min_open_interest(self):
+        filtered = filter_dataframe(self.df, "", ["Politics", "Sports"], False, 0.0, 0, 1000)
+        self.assertTrue((filtered["openInterest"] >= 1000).all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute `probability` and `hoursLeft` columns
- add sidebar controls for search, categories, sports toggle, sliders, and sorting
- show total markets count and filtered count
- add unit tests for filtering logic

## Testing
- `python -m py_compile app/main.py tests/test_filters.py`
- `python -m unittest tests.test_filters -v`
