### PR TITLE
Fix hours_to_expiry for non-string date values

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ streamlit run app/main.py
 ```
 
 The app fetches market data asynchronously and caches results in memory for 60 seconds to avoid excessive API calls.
+
+# User-provided custom instructions

--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ def hours_to_expiry(market: Dict[str, Any]) -> float:
         market.get("endsAt")
         or market.get("endDate")
         or market.get("expiry"))
-    if not date_str:
+    if not isinstance(date_str, str) or not date_str:
         return 0.0
     try:
         dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))


### PR DESCRIPTION
## Summary
- handle non-string dates in `hours_to_expiry`
- add user custom instructions note to README

## Testing
- `python -m py_compile app/main.py`
