### PR TITLE
Add sidebar filters and sorting

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,64 +38,148 @@ async def fetch_markets() -> List[Dict[str, Any]]:
     return markets
 
 
-def hours_to_expiry(market: Dict[str, Any]) -> float:
-    """Return the remaining hours until market resolution."""
-    date_str = (
-        market.get("endsAt")
-        or market.get("endDate")
-        or market.get("expiry"))
-    if not date_str:
-        return 0.0
+def hours_left(date_val: Any) -> float:
+    """Return hours remaining until the given end date."""
+    if not isinstance(date_val, str) or not date_val:
+        return -1.0
+    date_val = date_val.replace("Z", "+00:00")
     try:
-        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(date_val)
     except ValueError:
-        return 0.0
+        return -1.0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
     delta = dt - datetime.now(timezone.utc)
     return round(delta.total_seconds() / 3600, 2)
 
 
+def normalize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute helper columns for filtering and sorting."""
+    if df.empty:
+        return df
+    df["endDate"] = df.apply(
+        lambda r: r.get("endDate") or r.get("endsAt") or r.get("expiry"), axis=1
+    )
+    for col in ["yesPrice", "noPrice", "openInterest", "volume24hr"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    df["probability"] = df[["yesPrice", "noPrice"]].max(axis=1, skipna=True)
+    df["hoursLeft"] = df["endDate"].apply(hours_left)
+    return df
+
+
 def load_dataframe() -> pd.DataFrame:
-    """Load markets into a DataFrame with computed columns."""
+    """Fetch markets and prepare a DataFrame."""
     markets = asyncio.run(fetch_markets())
     df = pd.DataFrame(markets)
-    if not df.empty:
-        df["hoursToExpiry"] = df.apply(hours_to_expiry, axis=1)
-    return df
+    return normalize_dataframe(df)
+
+
+def filter_dataframe(
+    df: pd.DataFrame,
+    search: str,
+    categories: List[str],
+    hide_sports: bool,
+    min_prob: float,
+    min_hours: int,
+    min_open: float,
+) -> pd.DataFrame:
+    """Apply sidebar filters in the required order."""
+    result = df.copy()
+    if hide_sports and "category" in result.columns:
+        result = result[~result["category"].str.contains("sports", case=False, na=False)]
+    if categories and "category" in result.columns:
+        result = result[result["category"].isin(categories)]
+    if search:
+        s = search.lower()
+        result = result[
+            result.get("question", "").str.lower().str.contains(s, na=False)
+            | result.get("slug", "").str.lower().str.contains(s, na=False)
+        ]
+    if "probability" in result.columns:
+        result = result[result["probability"] >= min_prob]
+    if "hoursLeft" in result.columns:
+        result = result[result["hoursLeft"] >= float(min_hours)]
+    if "openInterest" in result.columns:
+        result = result[result["openInterest"] >= float(min_open)]
+    return result
+
+
+def sort_dataframe(df: pd.DataFrame, option: str) -> pd.DataFrame:
+    """Sort markets based on the dropdown selection."""
+    mapping = {
+        "24h volume": ("volume24hr", False),
+        "openInterest": ("openInterest", False),
+        "endDate asc": ("endDate", True),
+        "endDate desc": ("endDate", False),
+        "probability asc": ("probability", True),
+        "probability desc": ("probability", False),
+    }
+    if option not in mapping:
+        return df
+    col, asc = mapping[option]
+    if col not in df.columns:
+        return df
+    return df.sort_values(col, ascending=asc)
 
 
 def main() -> None:
     st.set_page_config(page_title="Polymarket Browser", layout="wide")
     st.title("Polymarket Markets (Read-Only)")
 
-    st.sidebar.header("Filters")
-    min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
-    min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
-    min_open_interest = st.sidebar.number_input(
-        "Min openInterest USDC", value=1000, step=100
-    )
-
     df = load_dataframe()
+    st.write(f"Total current available markets: {len(df)}")
+
     if df.empty:
         st.info("No market data available.")
         return
 
-    df_filtered = df.copy()
-    if "yesPrice" in df_filtered.columns and "noPrice" in df_filtered.columns:
-        prob_col = df_filtered[["yesPrice", "noPrice"]].max(axis=1)
-        df_filtered = df_filtered[prob_col >= min_prob]
+    st.sidebar.header("Filters")
+    search = st.sidebar.text_input("Search")
+    categories = sorted(df["category"].dropna().unique().tolist()) if "category" in df.columns else []
+    selected_categories = st.sidebar.multiselect("Category", categories, default=categories)
+    hide_sports = st.sidebar.checkbox("Hide sports markets")
+    min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
+    min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
+    min_open_interest = st.sidebar.number_input("Min openInterest USDC", value=1000, step=100)
+    sort_opt = st.sidebar.selectbox(
+        "Sort by",
+        [
+            "24h volume",
+            "openInterest",
+            "endDate asc",
+            "endDate desc",
+            "probability asc",
+            "probability desc",
+        ],
+    )
 
-    if "hoursToExpiry" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["hoursToExpiry"] >= min_hours]
-
-    if "openInterest" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
+    filtered = filter_dataframe(
+        df,
+        search=search,
+        categories=selected_categories,
+        hide_sports=hide_sports,
+        min_prob=min_prob,
+        min_hours=min_hours,
+        min_open=min_open_interest,
+    )
+    sorted_df = sort_dataframe(filtered, sort_opt)
 
     columns = [
-        col
-        for col in ["question", "yesPrice", "noPrice", "openInterest", "hoursToExpiry"]
-        if col in df_filtered.columns
+        c
+        for c in [
+            "question",
+            "yesPrice",
+            "noPrice",
+            "probability",
+            "hoursLeft",
+            "openInterest",
+            "volume24hr",
+            "category",
+        ]
+        if c in sorted_df.columns
     ]
-    st.dataframe(df_filtered[columns])
+    st.dataframe(sorted_df[columns])
 
 
 if __name__ == "__main__":

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,48 @@
+import unittest
+import pandas as pd
+
+from app.main import normalize_dataframe, filter_dataframe
+
+class FilterTests(unittest.TestCase):
+    def setUp(self):
+        data = [
+            {
+                "question": "Will A happen?",
+                "slug": "a",
+                "category": "Politics",
+                "yesPrice": "0.8",
+                "noPrice": "0.2",
+                "openInterest": "1500",
+                "volume24hr": 200,
+                "endDate": "2030-01-01T00:00:00Z",
+            },
+            {
+                "question": "Will B happen?",
+                "slug": "b",
+                "category": "Sports",
+                "yesPrice": "0.4",
+                "noPrice": "0.6",
+                "openInterest": "500",
+                "volume24hr": 50,
+            },
+        ]
+        self.df = normalize_dataframe(pd.DataFrame(data))
+
+    def test_hours_left_missing(self):
+        self.assertEqual(self.df.loc[1, "hoursLeft"], -1)
+
+    def test_filtering(self):
+        filtered = filter_dataframe(
+            self.df,
+            search="a",
+            categories=["Politics"],
+            hide_sports=True,
+            min_prob=0.5,
+            min_hours=0,
+            min_open=1000,
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered.iloc[0]["slug"], "a")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute `probability` and `hoursLeft` when loading data
- add `filter_dataframe` and `sort_dataframe` helpers
- implement sidebar controls for searching, categories, hiding sports, numeric filters, and sorting
- show total markets loaded and apply ordered filters
- add tests for missing endDate and basic filtering

## Testing
- `python -m py_compile app/main.py tests/test_filters.py`
- `python -m unittest tests.test_filters -v`
