### PR TITLE
Fix filtering by computing hoursLeft and probability first

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,28 +38,93 @@ async def fetch_markets() -> List[Dict[str, Any]]:
     return markets
 
 
-def hours_to_expiry(market: Dict[str, Any]) -> float:
-    """Return the remaining hours until market resolution."""
+def hours_left(market: Dict[str, Any]) -> float:
+    """Return remaining hours until market resolution or -1 if unknown."""
     date_str = (
-        market.get("endsAt")
-        or market.get("endDate")
-        or market.get("expiry"))
-    if not date_str:
-        return 0.0
+        market.get("endDate")
+        or market.get("endsAt")
+        or market.get("expiry")
+    )
+    if not isinstance(date_str, str) or not date_str:
+        return -1.0
     try:
         dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
     except ValueError:
-        return 0.0
+        return -1.0
     delta = dt - datetime.now(timezone.utc)
     return round(delta.total_seconds() / 3600, 2)
 
 
+def normalize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Add probability and hoursLeft columns to the DataFrame."""
+    if df.empty:
+        return df
+    for col in ["yesPrice", "noPrice", "openInterest", "volume24h"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    if {"yesPrice", "noPrice"}.issubset(df.columns):
+        df["probability"] = df[["yesPrice", "noPrice"]].max(axis=1, skipna=True)
+    else:
+        df["probability"] = pd.NA
+    df["hoursLeft"] = df.apply(hours_left, axis=1)
+    return df
+
+
 def load_dataframe() -> pd.DataFrame:
-    """Load markets into a DataFrame with computed columns."""
+    """Load markets and normalize the DataFrame."""
     markets = asyncio.run(fetch_markets())
     df = pd.DataFrame(markets)
-    if not df.empty:
-        df["hoursToExpiry"] = df.apply(hours_to_expiry, axis=1)
+    return normalize_dataframe(df)
+
+
+def filter_dataframe(
+    df: pd.DataFrame,
+    search: str,
+    categories: List[str],
+    hide_sports: bool,
+    min_prob: float,
+    min_hours: int,
+    min_open_interest: int,
+) -> pd.DataFrame:
+    df_filtered = df.copy()
+
+    if hide_sports and "category" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["category"].str.lower() != "sports"]
+
+    if categories and "category" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["category"].isin(categories)]
+
+    if search:
+        mask = df_filtered["question"].str.contains(search, case=False, na=False)
+        if "slug" in df_filtered.columns:
+            mask |= df_filtered["slug"].str.contains(search, case=False, na=False)
+        df_filtered = df_filtered[mask]
+
+    if "probability" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["probability"] >= min_prob]
+    if "hoursLeft" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["hoursLeft"] >= min_hours]
+    if "openInterest" in df_filtered.columns:
+        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
+
+    return df_filtered
+
+
+def sort_dataframe(df: pd.DataFrame, option: str) -> pd.DataFrame:
+    if option == "24h volume" and "volume24h" in df.columns:
+        return df.sort_values("volume24h", ascending=False)
+    if option == "openInterest" and "openInterest" in df.columns:
+        return df.sort_values("openInterest", ascending=False)
+    if option == "endDate asc":
+        return df.sort_values("hoursLeft")
+    if option == "endDate desc":
+        return df.sort_values("hoursLeft", ascending=False)
+    if option == "probability asc":
+        return df.sort_values("probability")
+    if option == "probability desc":
+        return df.sort_values("probability", ascending=False)
     return df
 
 
@@ -67,33 +132,64 @@ def main() -> None:
     st.set_page_config(page_title="Polymarket Browser", layout="wide")
     st.title("Polymarket Markets (Read-Only)")
 
+    df = load_dataframe()
+    st.write(f"Total current available markets: {len(df)}")
+    if df.empty:
+        st.info("No market data available.")
+        return
+
+    category_options: List[str] = []
+    if "category" in df.columns:
+        category_options = sorted(df["category"].dropna().unique().tolist())
+
     st.sidebar.header("Filters")
+    search = st.sidebar.text_input("Search")
+    selected_categories = st.sidebar.multiselect(
+        "Categories", category_options, default=category_options
+    )
+    hide_sports = st.sidebar.checkbox("Hide sports markets")
     min_prob = st.sidebar.slider("Min implied probability", 0.5, 1.0, 0.85, 0.01)
     min_hours = st.sidebar.slider("Min hours to expiry", 0, 48, 6)
     min_open_interest = st.sidebar.number_input(
         "Min openInterest USDC", value=1000, step=100
     )
+    sort_option = st.sidebar.selectbox(
+        "Sort by",
+        [
+            "24h volume",
+            "openInterest",
+            "endDate asc",
+            "endDate desc",
+            "probability asc",
+            "probability desc",
+        ],
+    )
 
-    df = load_dataframe()
-    if df.empty:
-        st.info("No market data available.")
-        return
+    df_filtered = filter_dataframe(
+        df,
+        search,
+        selected_categories,
+        hide_sports,
+        min_prob,
+        min_hours,
+        min_open_interest,
+    )
+    df_filtered = sort_dataframe(df_filtered, sort_option)
 
-    df_filtered = df.copy()
-    if "yesPrice" in df_filtered.columns and "noPrice" in df_filtered.columns:
-        prob_col = df_filtered[["yesPrice", "noPrice"]].max(axis=1)
-        df_filtered = df_filtered[prob_col >= min_prob]
-
-    if "hoursToExpiry" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["hoursToExpiry"] >= min_hours]
-
-    if "openInterest" in df_filtered.columns:
-        df_filtered = df_filtered[df_filtered["openInterest"] >= min_open_interest]
-
+    st.write(f"Markets after filtering: {len(df_filtered)}")
     columns = [
-        col
-        for col in ["question", "yesPrice", "noPrice", "openInterest", "hoursToExpiry"]
-        if col in df_filtered.columns
+        c
+        for c in [
+            "question",
+            "yesPrice",
+            "noPrice",
+            "probability",
+            "hoursLeft",
+            "openInterest",
+            "volume24h",
+            "category",
+        ]
+        if c in df_filtered.columns
     ]
     st.dataframe(df_filtered[columns])
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,60 @@
+import unittest
+
+import pandas as pd
+
+from app.main import normalize_dataframe, filter_dataframe
+
+
+class FilterTests(unittest.TestCase):
+    def test_filters(self):
+        df = pd.DataFrame([
+            {
+                "question": "Foo",
+                "slug": "foo",
+                "category": "Sports",
+                "yesPrice": 0.6,
+                "noPrice": 0.4,
+                "openInterest": 2000,
+                "volume24h": 100,
+                "endDate": "2100-01-01T00:00:00Z",
+            },
+            {
+                "question": "Bar",
+                "slug": "bar",
+                "category": "Politics",
+                "yesPrice": 0.7,
+                "noPrice": 0.3,
+                "openInterest": 500,
+                "volume24h": 50,
+                "endDate": None,
+            },
+        ])
+        df = normalize_dataframe(df)
+        self.assertEqual(df.loc[1, "hoursLeft"], -1.0)
+
+        filtered = filter_dataframe(
+            df,
+            search="foo",
+            categories=["Sports"],
+            hide_sports=False,
+            min_prob=0.5,
+            min_hours=0,
+            min_open_interest=0,
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered.iloc[0]["slug"], "foo")
+
+        filtered = filter_dataframe(
+            df,
+            search="",
+            categories=["Politics"],
+            hide_sports=False,
+            min_prob=0.6,
+            min_hours=1,
+            min_open_interest=1000,
+        )
+        self.assertTrue(filtered.empty)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute `hoursLeft` and `probability` before applying filters
- add helpers to filter and sort by sidebar controls
- show total markets loaded and update the dashboard with search, category, hide-sports, and sorting widgets
- include a unit test covering the filter logic

## Testing
- `python -m py_compile app/main.py tests/test_filters.py`
- `python -m unittest tests.test_filters -v`